### PR TITLE
WIKI-965: Add xwiki dependencies of Formula and Chart macro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -866,6 +866,11 @@
         <version>${org.xwiki.platform.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.xwiki.commons</groupId>
+        <artifactId>xwiki-commons-environment-standard</artifactId>
+        <version>${org.xwiki.platform.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.xwiki.platform</groupId>
         <artifactId>xwiki-platform-gwt-dom</artifactId>
         <version>${org.xwiki.platform.version}</version>
@@ -882,12 +887,37 @@
       </dependency>
       <dependency>
         <groupId>org.xwiki.platform</groupId>
+        <artifactId>xwiki-platform-cache-infinispan</artifactId>
+        <version>${org.xwiki.platform.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.xwiki.platform</groupId>
+        <artifactId>xwiki-platform-formula-renderer</artifactId>
+        <version>${org.xwiki.platform.version}</version>
+      </dependency>      
+      <dependency>
+        <groupId>org.xwiki.platform</groupId>
         <artifactId>xwiki-platform-rendering-macro-code</artifactId>
         <version>${org.xwiki.platform.version}</version>
       </dependency>
       <dependency>
         <groupId>org.xwiki.platform</groupId>
+        <artifactId>xwiki-platform-chart-macro</artifactId>
+        <version>${org.xwiki.platform.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.xwiki.platform</groupId>
         <artifactId>xwiki-platform-rendering-macro-rss</artifactId>
+        <version>${org.xwiki.platform.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.xwiki.platform</groupId>
+        <artifactId>xwiki-platform-formula-macro</artifactId>
+        <version>${org.xwiki.platform.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.xwiki.platform</groupId>
+        <artifactId>xwiki-platform-rendering-macro-cache</artifactId>
         <version>${org.xwiki.platform.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Description:
- Revert DEP-93, WIKI-993: Remove xwiki dependencies of Formula and Chart macros
- Remove unused dependency: Office.
