### PR TITLE
DEP-105: Upgrade xpp3 from 1.1.4c to 1.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
     <org.juzu.version>1.1.0-M1</org.juzu.version>
     <org.liquibase.version>3.4.1</org.liquibase.version>
     <org.mockito.version>1.8.5</org.mockito.version>
+    <org.ogce.xpp3.version>1.1.6</org.ogce.xpp3.version>
     <org.owasp.antisamy.version>1.4.5</org.owasp.antisamy.version>
     <org.picketlink.idm.version>1.4.6.Final</org.picketlink.idm.version>
     <org.slf4j.version>1.7.7</org.slf4j.version>
@@ -146,7 +147,6 @@
     <rome.version>1.0</rome.version>
     <xerces.version>2.9.1</xerces.version>
     <xml-apis.version>1.3.04</xml-apis.version>
-    <xpp3.version>1.1.4c</xpp3.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -728,6 +728,11 @@
         <version>${org.mockito.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.ogce</groupId>
+        <artifactId>xpp3</artifactId>
+        <version>${org.ogce.xpp3.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.owasp.antisamy</groupId>
         <artifactId>antisamy</artifactId>
         <version>${org.owasp.antisamy.version}</version>
@@ -1107,11 +1112,6 @@
         <groupId>xml-apis</groupId>
         <artifactId>xml-apis</artifactId>
         <version>${xml-apis.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>xpp3</groupId>
-        <artifactId>xpp3</artifactId>
-        <version>${xpp3.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     <rome.version>1.0</rome.version>
     <xerces.version>2.9.1</xerces.version>
     <xml-apis.version>1.3.04</xml-apis.version>
+    <xpp3.version>1.1.4c</xpp3.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -1112,6 +1113,11 @@
         <groupId>xml-apis</groupId>
         <artifactId>xml-apis</artifactId>
         <version>${xml-apis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>xpp3</groupId>
+        <artifactId>xpp3</artifactId>
+        <version>${xpp3.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
The groupId is updated from xpp3 to org.ogce.

As the maven properties use the groupId and all maven properties and dependencies are sorted alphabetically, the new property and dependency have been moved to the top of the file.