### PR TITLE
DEP-149 : Update Hibernate dependencies 4.1.12.Final -> 4.2.21.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
     <org.exoplatform.framework.junit.version>1.2.4-GA</org.exoplatform.framework.junit.version>
     <org.hamcrest.version>1.3</org.hamcrest.version>
     <org.hibernate.common.hibernate-commons-annotations.version>4.0.5.Final</org.hibernate.common.hibernate-commons-annotations.version>
-    <org.hibernate.hibernate-core.version>4.1.12.Final</org.hibernate.hibernate-core.version>
-    <org.hibernate.hibernate-entitymanager.version>4.1.12.Final</org.hibernate.hibernate-entitymanager.version>
+    <org.hibernate.hibernate-core.version>4.2.21.Final</org.hibernate.hibernate-core.version>
+    <org.hibernate.hibernate-entitymanager.version>4.2.21.Final</org.hibernate.hibernate-entitymanager.version>
     <org.hibernate.hibernate-validator.version>4.2.0.Final</org.hibernate.hibernate-validator.version>
     <org.hsqldb.version>2.3.3</org.hsqldb.version>
     <org.icepdf.version>5.1.1</org.icepdf.version>


### PR DESCRIPTION
Update Hibernate dependencies 4.1.12.Final -> 4.2.21.Final.

I just noticed it adds the 2 following jars :
- c3p0-0.9.2.1.jar
- mchange-commons-java-0.2.3.4.jar

When I look at the dependency tree, for 4.1.12.Final :

`[INFO] |  |  +- org.exoplatform.core:exo.core.component.organization.jdbc:jar:2.7.x-SNAPSHOT:runtime
[INFO] |  |  |  \- org.hibernate:hibernate-c3p0:jar:4.1.12.Final:runtime`

and for 4.2.21.Final :

`+- org.exoplatform.core:exo.core.component.organization.jdbc:jar:2.7.x-SNAPSHOT:runtime
[INFO] |  |  |  \- org.hibernate:hibernate-c3p0:jar:4.2.21.Final:runtime
[INFO] |  |  |     \- com.mchange:c3p0:jar:0.9.2.1:runtime
[INFO] |  |  |        \- com.mchange:mchange-commons-java:jar:0.2.3.4:runtime`

@mgreau is that ok for you ?
