### PR TITLE
DEP-151 Add dependency to Elastic Search in Parent Dependencies POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -594,6 +594,12 @@
         <version>${org.elasticsearch.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.elasticsearch.distribution.zip</groupId>
+        <artifactId>elasticsearch</artifactId>
+        <version>${org.elasticsearch.version}</version>
+        <type>zip</type>
+      </dependency>
+      <dependency>
         <groupId>org.exoplatform.tool</groupId>
         <artifactId>exo.tool.framework.junit</artifactId>
         <version>${org.exoplatform.framework.junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -584,6 +584,12 @@
         <version>${org.elasticsearch.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.elasticsearch.distribution.zip</groupId>
+        <artifactId>elasticsearch</artifactId>
+        <version>${org.elasticsearch.version}</version>
+        <type>zip</type>
+      </dependency>
+      <dependency>
         <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>mapper-attachments</artifactId>
         <version>${org.elasticsearch.version}</version>
@@ -592,12 +598,6 @@
         <groupId>org.elasticsearch.plugin</groupId>
         <artifactId>delete-by-query</artifactId>
         <version>${org.elasticsearch.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.elasticsearch.distribution.zip</groupId>
-        <artifactId>elasticsearch</artifactId>
-        <version>${org.elasticsearch.version}</version>
-        <type>zip</type>
       </dependency>
       <dependency>
         <groupId>org.exoplatform.tool</groupId>


### PR DESCRIPTION
We are using Elastic Search in several projects.
We need to centralize this dependency:
<groupId>org.elasticsearch.distribution.zip</groupId>
<artifactId>elasticsearch</artifactId>
<version>2.3.2</version>
<type>zip</type>
