### PR TITLE
PLF-7133: Declare dependency section for juzu-plugins-less4j / juzu-p…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -726,6 +726,21 @@
         <version>${org.juzu.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-less4j</artifactId>
+        <version>${org.juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-validation</artifactId>
+        <version>${org.juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-webjars</artifactId>
+        <version>${org.juzu.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-core</artifactId>
         <version>${org.liquibase.version}</version>


### PR DESCRIPTION
…lugins-validation and juzu-plugins-webjars

  * Those dependencies are added to fix the different versions of Juzu Core & Plugins in PLF Packaging Archive due to platform POM configuration.