### PR TITLE
DEP-154: Upgrade apache commons-fileupload to 1.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <commons-chain.version>1.2</commons-chain.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-fileupload.version>1.3.2</commons-fileupload.version>
+    <commons-fileupload.version>1.3.3</commons-fileupload.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
     <commons-io.version>2.4</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>


### PR DESCRIPTION
  * This version fixes the vulnerability CVE-2016-1000031

From https://commons.apache.org/proper/commons-fileupload/security-reports.html

> Notes on Apache Commons FileUpload 1.3.3 
Beginning with 1.3.3, the class DiskFileItem is still implementing the interface java.io.Serializable. In other words, it still declares itself as serializable, and deserializable to the JVM. In practice, however, an attempt to deserialize an instance of DiskFileItem will trigger an Exception. In the unlikely case, that your application depends on the deserialization of DiskFileItems, you can revert to the previous behaviour by setting the system property "org.apache.commons.fileupload.disk.DiskFileItem.serializable" to "true".