### PR TITLE
PLF-8098 : update Elasticsearch from 5.6.3 to 5.6.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <org.codehaus.cargo.version>0.9</org.codehaus.cargo.version>
     <org.codehaus.groovy.version>2.4.12</org.codehaus.groovy.version>
     <org.cometd.version>3.0.8</org.cometd.version>
-    <org.elasticsearch.version>5.6.3</org.elasticsearch.version>
+    <org.elasticsearch.version>5.6.11</org.elasticsearch.version>
     <org.exoplatform.framework.junit.version>1.2.4-GA</org.exoplatform.framework.junit.version>
     <org.hamcrest.version>1.3</org.hamcrest.version>
     <org.hibernate.common.hibernate-commons-annotations.version>4.0.5.Final</org.hibernate.common.hibernate-commons-annotations.version>


### PR DESCRIPTION
Upgrade Elasticsearch from 5.6.3 to 5.6.11.