### PR TITLE
PLF-8433 : upgrade Swagger library to 1.5.22 to upgrade Jackson library to 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dom4j.version>1.6.1</dom4j.version>
     <ecs.version>1.4.2</ecs.version>
     <ical4j.version>1.0-beta5</ical4j.version>
-    <io.swagger.version>1.5.0</io.swagger.version>
+    <io.swagger.version>1.5.22</io.swagger.version>
     <javax.activation.version>1.1.1</javax.activation.version>
     <javax.annotation.version>1.0</javax.annotation.version>
     <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
The goal of this change is to upgrade Jackson library to a more recent version.
Since the Jackson library is mainly pulled by the Swagger library, we take this opportunity to also upgrade Swagger.

The Jackson library is directly used in the following projects:
* integration
  * integ-social/integ-social-ecms/src/main/java/org/exoplatform/social/ckeditor/listener/ActivityImageLinkUpdateListener.java
  * integration/integ-social/integ-social-ecms/src/test/java/org/exoplatform/social/addons/rdbms/listener/ActivityImageLinkUpdateListenerTest.java

This usage has been removed, see [integration PR](https://github.com/exodev/integration/pull/244).

* gamification
  * services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/DomainDTO.java
  * services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/RuleDTO.java
  * services/src/main/java/org/exoplatform/addons/gamification/entities/domain/configuration/AbstractAuditingEntity.java

The Jackson dependency is pulled through a transitive dependency of io.swagger:swagger-jaxrs and org.exoplatform.social:social-component-service (ideally we should add a direct dependency to com.fasterxml.jackson.core:jackson-annotations).

* wallet
  * wallet-webapps-common/src/main/java/org/exoplatform/addon/wallet/blockchain/service/EthereumWalletTokenAdminService.java

The Jackson dependency is pulled through a transitive dependency of io.swagger:swagger-jaxrs and org.web3j:core (ideally we should add a direct dependency to com.fasterxml.jackson.core:jackson-databind).

With this change, the following jars are updated in the PLF package:
* jackson-annotations : 2.3.0 -> 2.9.8
* jackson-core : 2.3.1 -> 2.9.8
* jackson-databind : 2.3.1 -> 2.9.8
* jackson-dataformat-yaml : 2.4.2 -> 2.9.8
* reflections : 0.9.9 -> 0.9.11 (swagger dependency)
* swagger-annotations : 1.5.0 -> 1.5.22
* swagger-core : 1.5.0 -> 1.5.22
* swagger-jaxrs : 1.5.0 -> 1.5.22
* swagger-models : 1.5.0 -> 1.5.22

and the following ones are removed:
* annotations-2.0.1 (com.google.code.findbugs:annotations : not anymore a reflections dependency)
* jackson-dataformat-xml-2.4.2
* jackson-datatype-joda-2.4.2
* jackson-jaxrs-base-2.4.2
* jackson-jaxrs-json-provider-2.4.2
* jackson-module-jaxb-annotations-2.4.2
* stax2-api-3.1.4 (dependency of com.fasterxml.jackson.dataformat:jackson-dataformat-xml)
